### PR TITLE
FIX: Friend Online & chat socket close at logout

### DIFF
--- a/src/Chat/chatApp.js
+++ b/src/Chat/chatApp.js
@@ -191,6 +191,12 @@ class ChatApp {
     getFriendsOnline() {
         return this._friendsOnline;
     }
+
+    closeSocket() {
+        if (this._chatSocket !== undefined) {
+            this._chatSocket.close();
+        }
+    }
 }
 
 export default ChatApp;

--- a/src/Login/loginUtils.js
+++ b/src/Login/loginUtils.js
@@ -126,11 +126,11 @@ export function changeTo2FAPage(loginUser) {
   });
 
   twoFABtn.addEventListener('click', async () => {
-        const status = await loginUser.send2FACode(codeInput.value);
-        const infoContainer = loginBody.querySelector('.login__body--info');
-
-        infoContainer.innerHTML = "";
         try {
+            const infoContainer = loginBody.querySelector('.login__body--info');
+            await loginUser.send2FACode(codeInput.value);
+
+            infoContainer.innerHTML = "";
             await renderMainPage();
         } catch (e) {
             infoContainer.innerHTML = "Wrong code!";

--- a/src/Login/player.js
+++ b/src/Login/player.js
@@ -211,6 +211,10 @@ class Player {
         };
     }
 
+    setChatApp(chatApp) {
+        this._chatApp = chatApp;
+    }
+
     forgetMe() {
         this._status = USER_STATUS.DOSE_NOT_EXIST;
         this._token = undefined;
@@ -222,6 +226,11 @@ class Player {
         this._lose = undefined;
         this._rank = undefined;
         this._set_2fa = undefined;
+
+        if (this._chatApp !== undefined) {
+            this._chatApp.closeSocket();
+            this._chatApp = undefined;
+        }
     }
 }
 

--- a/src/Profile/modalUtils.js
+++ b/src/Profile/modalUtils.js
@@ -48,6 +48,7 @@ export function toggleAddAndDeleteBtn(chatApp, btnNode, id, doing) {
         btnNode.onclick = async () => {
             await player.friend(id, doing);
 
+            chatApp.setFriendsOnline(id, doing);
             btnNode.innerHTML = buttonMsg[1];
             toggleAddAndDeleteBtn(chatApp, btnNode, id, doing === DOING.ADD? DOING.DELETE : DOING.ADD);
             await setFriendList(chatApp);

--- a/src/app.js
+++ b/src/app.js
@@ -12,7 +12,8 @@ const application = async () => {
         const app = document.getElementById('app');
 
         await player.whoAmI(token);
-        player._chatApp = new ChatApp(app);
+        const chatApp = new ChatApp(app);
+        player.setChatApp(chatApp);
     }
     await renderMainPage();
 }


### PR DESCRIPTION
## Friend Online
- [x] 기존의 friendList 부분에서 온라인 표시가 제대로 이루어지지 않는 버그를 수정하였습니다!
  + chatting서버에서 친구의 온/오프라인 상태를 추가적으로 알려줄 때, `chatApp._friendOnline` 리스트 갱신 추가
- [x] friend add/delete 부분에서도 새로 추가할 시에 그 친구에 대한 정보를 받아오지 않아 갱신이 되지 않았는데, 이번에 추가했습니다!
  + chatting서버에서 id의 관한 추가 온라인 상태 확인 가능.
## chat socket close at logout
- [x] Logout해도 상대방에게 그대로 온라인 표시가 되었었는데, SPA로 바꾸는 과정 중 chat socket을 밖으로 꺼내면서 제대로 닫히지 않아 발생하는 문제입니다.
  + `player.forgetMe()` 에서 chatSocket을 close합니다!