### PR TITLE
FEAT: local tournament board modal

### DIFF
--- a/src/Game/SocketApp.js
+++ b/src/Game/SocketApp.js
@@ -16,7 +16,7 @@ import {
     toggleFocusOut,
     setupLocalTournaNextMatch,
     setupNextMatchAtBoardModal,
-    finalWinnerBoardModalSetting,
+    setFinalWinnerBoardModal,
     getPlayerIdxInPlayerList,
     isWin
 } from "./gameUtils.js";
@@ -121,7 +121,7 @@ class SocketApp {
     }
 
     finalWinner() {
-        finalWinnerBoardModalSetting(this, this._boardContainer);
+        setFinalWinnerBoardModal(this, this._boardContainer);
     }
 
     localTwo(playerInfo = player.getInfo(), guestInfo = generateGuest('GUEST', [player.getProfile()])) {

--- a/src/Game/SocketApp.js
+++ b/src/Game/SocketApp.js
@@ -14,7 +14,7 @@ import {
     orderPlayers,
     exitInviteGame,
     toggleFocusOut,
-    setupLocalTournaNextMatch,
+    setLocalNextMatchBoard,
     setupNextMatchAtBoardModal,
     setFinalWinnerBoardModal,
     getPlayerIdxInPlayerList,
@@ -275,6 +275,8 @@ class SocketApp {
                 } else if (data.message === 'Game End') {
                     if (gameType === GAME_TYPE.TOURNAMENT && this._round === 1 && isWin(this._gameApp.getPlayer(), data.score)) {
                         this._waitNextMatch = true;
+                    } else if (gameType === GAME_TYPE.LOCAL_TWO) {
+                        this._waitNextMatch = false;
                     }
                     toggleFocusOut(this._gameCanvas, false);
                     renderEndStatus(this._gameCanvas, this._gameApp.getPlayer(), data.score, gameType);
@@ -282,17 +284,21 @@ class SocketApp {
                     this._gaming = false;
                     if (gameType === GAME_TYPE.LOCAL_TOURNAMENT) {
                         changeEndToNextMatch(this._gameContainer);
+                        this._waitNextMatch = true;
                         this._gameContainer.querySelector('.exitgame__btn').onclick = () => {
                             this.gameClose();
                             this.cancelRenderGameApp();
                             this.closeAllModal();
 
+                            setLocalNextMatchBoard(this._boardContainer);
+                            this._boardContainer.style.opacity = '1';
+                            this.appearBoardModal();
+
                             if (JSON.parse(localStorage.getItem("local_tournament")).length === 2) {
-                                openBoardModal(this, GAME_TYPE.LOCAL_TOURNAMENT, this._allPlayerList);
-                                setupLocalTournaNextMatch(this._boardContainer);
                                 this._enterGameRoom(`local/${crypto.randomUUID()}`, GAME_TYPE.LOCAL_TWO, [JSON.parse(localStorage.getItem("local_tournament"))[0], JSON.parse(localStorage.getItem("local_tournament"))[1]]);
+                                // TODO: 이거 끝나면 You win 대신 finalWinnerBoard 띄워야 하눈디.. ㅎㅎ
+                                // isWaitNextMatch === true면 띄우기 ! !
                             } else {
-                                openBoardModal(this, GAME_TYPE.LOCAL_TWO, userList.slice(-2));
                                 this._enterGameRoom(`local/${crypto.randomUUID()}`, GAME_TYPE.LOCAL_TOURNAMENT, userList.slice(-2));
                             }
                         };
@@ -382,7 +388,7 @@ class SocketApp {
         this._matchingContainer = undefined;
 
         this._gameCanvas = undefined;
-        // this._allPlayerList = undefined;
+        this._allPlayerList = undefined;
         this._gaming = false;
         this._waitNextMatch = false;
         this._round = 0;

--- a/src/Game/SocketApp.js
+++ b/src/Game/SocketApp.js
@@ -127,8 +127,8 @@ class SocketApp {
     localTwo(playerInfo = player.getInfo(), guestInfo = generateGuest('GUEST', [player.getProfile()])) {
         const userList = [playerInfo, guestInfo];
 
-        openBoardModal(this, GAME_TYPE.TWO_PLAYER, userList);
-        this._enterGameRoom(`local/${crypto.randomUUID()}`, GAME_TYPE.TWO_PLAYER, userList);
+        openBoardModal(this, GAME_TYPE.LOCAL_TWO, userList);
+        this._enterGameRoom(`local/${crypto.randomUUID()}`, GAME_TYPE.LOCAL_TWO, userList);
     }
 
     localTournament(userList) {
@@ -136,8 +136,8 @@ class SocketApp {
             localStorage.removeItem("local_tournament");
 
         this._allPlayerList = userList;
-        openBoardModal(this, GAME_TYPE.TWO_TOURNAMENT, userList);
-        this._enterGameRoom(`local/${crypto.randomUUID()}`, GAME_TYPE.TWO_TOURNAMENT, userList);
+        openBoardModal(this, GAME_TYPE.LOCAL_TOURNAMENT, userList);
+        this._enterGameRoom(`local/${crypto.randomUUID()}`, GAME_TYPE.LOCAL_TOURNAMENT, userList);
     }
 
     inviteGameRoom(room_id, userList, chatApp) {
@@ -240,7 +240,7 @@ class SocketApp {
                         this._gameApp.renderCounter(data.counter);
                     }
                 } else if (data.message === 'Game Start') {
-                    if (gameType === GAME_TYPE.TWO_PLAYER || gameType === GAME_TYPE.TWO_TOURNAMENT) {
+                    if (gameType === GAME_TYPE.LOCAL_TWO || gameType === GAME_TYPE.LOCAL_TOURNAMENT) {
                         openPlayGameModal(this, userList);
                         changeGiveUpToEnd(this._gameContainer);
                         this._gameApp = new GameApp(this._gameCanvas, gameType);
@@ -280,7 +280,7 @@ class SocketApp {
                     renderEndStatus(this._gameCanvas, this._gameApp.getPlayer(), data.score, gameType);
                     changeGiveUpToEnd(this._gameContainer);
                     this._gaming = false;
-                    if (gameType === GAME_TYPE.TWO_TOURNAMENT) {
+                    if (gameType === GAME_TYPE.LOCAL_TOURNAMENT) {
                         changeEndToNextMatch(this._gameContainer);
                         this._gameContainer.querySelector('.exitgame__btn').onclick = () => {
                             this.gameClose();
@@ -288,12 +288,12 @@ class SocketApp {
                             this.closeAllModal();
 
                             if (JSON.parse(localStorage.getItem("local_tournament")).length === 2) {
-                                openBoardModal(this, GAME_TYPE.TWO_TOURNAMENT, this._allPlayerList);
+                                openBoardModal(this, GAME_TYPE.LOCAL_TOURNAMENT, this._allPlayerList);
                                 setupLocalTournaNextMatch(this._boardContainer);
-                                this._enterGameRoom(`local/${crypto.randomUUID()}`, GAME_TYPE.TWO_PLAYER, [JSON.parse(localStorage.getItem("local_tournament"))[0], JSON.parse(localStorage.getItem("local_tournament"))[1]]);
+                                this._enterGameRoom(`local/${crypto.randomUUID()}`, GAME_TYPE.LOCAL_TWO, [JSON.parse(localStorage.getItem("local_tournament"))[0], JSON.parse(localStorage.getItem("local_tournament"))[1]]);
                             } else {
-                                openBoardModal(this, GAME_TYPE.TWO_PLAYER, userList.slice(-2));
-                                this._enterGameRoom(`local/${crypto.randomUUID()}`, GAME_TYPE.TWO_TOURNAMENT, userList.slice(-2));
+                                openBoardModal(this, GAME_TYPE.LOCAL_TWO, userList.slice(-2));
+                                this._enterGameRoom(`local/${crypto.randomUUID()}`, GAME_TYPE.LOCAL_TOURNAMENT, userList.slice(-2));
                             }
                         };
                     }
@@ -304,7 +304,7 @@ class SocketApp {
         });
 
        gameSocket.onopen = () => {
-           if (gameType === GAME_TYPE.TWO_PLAYER || gameType === GAME_TYPE.TWO_TOURNAMENT) {
+           if (gameType === GAME_TYPE.LOCAL_TWO || gameType === GAME_TYPE.LOCAL_TOURNAMENT) {
                setupActiveReadyBtn(this._boardContainer);
            } else {
                this.readyToPlay();

--- a/src/Game/gameApp.js
+++ b/src/Game/gameApp.js
@@ -31,7 +31,7 @@ class PlayGameApp {
         this._renderer = renderer;
         this._scene = scene;
 
-        if (gameType === GAME_TYPE.TWO_PLAYER || gameType === GAME_TYPE.TWO_TOURNAMENT) {
+        if (gameType === GAME_TYPE.LOCAL_TWO || gameType === GAME_TYPE.LOCAL_TOURNAMENT) {
             this._camPosition = CAM_INDEX.MID;
         }
         this._setupCamera();

--- a/src/Game/gameTemplate.js
+++ b/src/Game/gameTemplate.js
@@ -2,8 +2,8 @@ export const GAME_TYPE = {
 	LOCAL_GAME: 0,
 	RANDOM: 1,
 	TOURNAMENT: 2,
-	TWO_PLAYER: 3,
-	TWO_TOURNAMENT: 4
+	LOCAL_TWO: 3,
+	LOCAL_TOURNAMENT: 4
 }
 
 class Game {

--- a/src/Game/gameUtils.js
+++ b/src/Game/gameUtils.js
@@ -113,7 +113,7 @@ export function openBoardModal(socketApp, gameType, players) {
     let modalName;
     let modalHtml;
 
-    if (gameType === GAME_TYPE.TOURNAMENT || gameType === GAME_TYPE.TWO_TOURNAMENT) {
+    if (gameType === GAME_TYPE.TOURNAMENT || gameType === GAME_TYPE.LOCAL_TOURNAMENT) {
         modalName = "tournament";
         modalHtml = routes['/game'].tournamentModalTemplate();
     } else {
@@ -123,14 +123,14 @@ export function openBoardModal(socketApp, gameType, players) {
 
     const modalContainer = modalRender(modalName, modalHtml, false);
 
-    if (gameType === GAME_TYPE.TWO_PLAYER || gameType === GAME_TYPE.TWO_TOURNAMENT) {
+    if (gameType === GAME_TYPE.LOCAL_TWO || gameType === GAME_TYPE.LOCAL_TOURNAMENT) {
         modalContainer.querySelector('.modal__ready-btn').addEventListener('click', () => {
             socketApp.readyToPlay();
         });
     }
 
     socketApp.setBoardContainer(modalContainer);
-    setupInfoAtModal(modalContainer, players, gameType === GAME_TYPE.RANDOM || gameType === GAME_TYPE.TWO_PLAYER);
+    setupInfoAtModal(modalContainer, players, gameType === GAME_TYPE.RANDOM || gameType === GAME_TYPE.LOCAL_TWO);
 }
 
 export function closeMatchingModal(matchingContainer, socketApp) {
@@ -360,13 +360,13 @@ export function renderEndStatus(gameContainer, gamePlayer, score, gameType) {
 
     let status = 'YOU <span class="game-modal__win">WIN!</span>';
 
-    if (gameType === GAME_TYPE.TWO_PLAYER && !localStorage.getItem("local_tournament")) {
+    if (gameType === GAME_TYPE.LOCAL_TWO && !localStorage.getItem("local_tournament")) {
         if (score[0] > score[1]) {
             status = `${player.getNickName()} <span class="game-modal__win">WIN!</span>`;
         } else {
             status = `GUEST <span class="game-modal__win">WIN!</span>`;
         }
-    } else if (gameType === GAME_TYPE.TWO_PLAYER || gameType === GAME_TYPE.TWO_TOURNAMENT) {
+    } else if (gameType === GAME_TYPE.LOCAL_TWO || gameType === GAME_TYPE.LOCAL_TOURNAMENT) {
         const players = gameContainer.parentNode.parentNode.querySelectorAll('.playgame__header--profile');
         let winnerIdx = 0;
 
@@ -380,7 +380,7 @@ export function renderEndStatus(gameContainer, gamePlayer, score, gameType) {
         let winnerProfile = players[winnerIdx].children[0].getAttribute('data-image');
         let winnerName = players[winnerIdx].children[1].innerText;
 
-        if (gameType === GAME_TYPE.TWO_PLAYER)
+        if (gameType === GAME_TYPE.LOCAL_TWO)
             localStorage.removeItem("local_tournament");
         else {
             let winners;

--- a/src/Game/gameUtils.js
+++ b/src/Game/gameUtils.js
@@ -138,10 +138,12 @@ export function closeMatchingModal(matchingContainer, socketApp) {
     matchingContainer.remove();
 }
 
-export function finalWinnerBoardModalSetting(socketApp, container) {
+export function setFinalWinnerBoardModal(socketApp, container) {
     const avatar = container.querySelector('.insert-finalAvatar');
     const winnerAvatars = container.querySelectorAll('.insert-winnerAvatar');
+    const title = container.querySelector('.tournament__header');
 
+    title.innerText = "Congratulations! You are the winner 🏆"
     winnerAvatars[1].classList.add('loser-avatar');
 
     avatar.classList.remove('anonymous-avatar');

--- a/src/Game/gameUtils.js
+++ b/src/Game/gameUtils.js
@@ -255,7 +255,7 @@ function handleLocalGame(socketApp) {
 
             for (let i = 0; i < 4; i++) {
                 if (aliasNames[i].value.length < 1) {
-                    alert("Alias name is required for every player!");
+                    openInfoModal("Alias name is required for every player!");
                     return ;
                 }
             }

--- a/src/Game/gameUtils.js
+++ b/src/Game/gameUtils.js
@@ -280,20 +280,19 @@ function handleLocalGame(socketApp) {
     });
 }
 
-export function setupLocalTournaNextMatch(boardContainer) {
+export function setLocalNextMatchBoard(boardContainer) {
     const winnerAvatars = boardContainer.querySelectorAll('.insert-winnerAvatar');
     const avatarNodes = boardContainer.querySelectorAll('.insert-playerAvatar');
     
     const winners = JSON.parse(localStorage.getItem("local_tournament"));
-    for (let i = 0; i < 2; i++) {
+    for (let i = 0; i < winners.length; i++) {
         winnerAvatars[i].setAttribute('data-image', winners[i].profile);
         winnerAvatars[i].classList.remove('anonymous-avatar');
     }
-    
-    avatarNodes.forEach(node => {
-        if (node.getAttribute('data-image') !== winners[0].profile && node.getAttribute('data-image') !== winners[1].profile)
-            node.classList.add('loser-avatar');
-    });
+    for (let i = 0; i < winners.length * 2; i++) {
+        if (avatarNodes[i].getAttribute('data-image') !== winners[i < 2 ? 0 : 1].profile)
+            avatarNodes[i].classList.add('loser-avatar');
+    }
 }
 
 export function handleGameModal() {


### PR DESCRIPTION
1. gameContiner => gameContainer 오타 수정
2. 로컬 토너먼트 alias name 설정 안 했을 때 alert 대신 openInfoModal 사용하도록 수정
3. 로컬 게임 함수로 분리
4. 로컬 토너먼트 보드 모달 추가
=> 이 부분 논의가 필요합니다! local Tournament 진행 시 socketApp._allPlayerList에 4명의 alias name과 프로필을 저장해두는데, 각 매치가 끝나면 closeAllModal()을 하는 과정에서 socketApp._allPlayerList가 초기화됩니다. 제 코드를 위해..... 이부분을 주석처리 해뒀는데 혹시 꼭 필요한 부분이면 제 쪽의 로직을 뭔가 바꾸도록 하겠습니다! PR은 닫으셔도 됩니다.
아직 결승전 끝났을 때는 보드를 다시 안 띄웁니다!